### PR TITLE
Rework snapshot releases and remove gupload as not present in builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,15 @@
 language: java
+sudo: false
+
 jdk:
   - oraclejdk8
   - oraclejdk7
   - openjdk7
   - openjdk6
-after_success:
-  - "git clone -b travis `git config --get remote.origin.url` target/travis"
-  - "mvn deploy --settings target/travis/settings.xml"
 
-branches:
-  except:
-    - travis
+after_success:
+  - chmod -R 777 ./travis/deploy-to-sonatype.sh
+  - ./travis/deploy-to-sonatype.sh
 
 env:
   global:

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
         <configuration>
-          <arguments>-Prelease,bundle,gupload</arguments>
+          <arguments>-Prelease,bundle</arguments>
         </configuration>
       </plugin>
     </plugins>

--- a/travis/deploy-to-sonatype.sh
+++ b/travis/deploy-to-sonatype.sh
@@ -1,0 +1,5 @@
+mybatis_repo=$(git config --get remote.origin.url 2>&1)
+if [ "$mybatis_repo" == "https://github.com/mybatis/hazelcast-cache.git" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
+  mvn deploy --settings ./travis/settings.xml
+  echo -e "Successfully deployed SNAPSHOT artifacts to Sonatype under Travis job ${TRAVIS_JOB_NUMBER}"
+fi

--- a/travis/settings.xml
+++ b/travis/settings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd">
+  <servers>
+    <server>
+      <id>ossrh</id>
+      <username>${env.CI_DEPLOY_USERNAME}</username>
+      <password>${env.CI_DEPLOY_PASSWORD}</password>
+    </server>
+  </servers>
+</settings>


### PR DESCRIPTION
Rework on snapshot will remove 'travis' branch.  Additionally, it will ensure snapshot only runs off mybatis repo not forks of the repo which will all get security violations due to encrypted info that is for mybatis repo only.