### PR TITLE
[pom] Use javadoc version property instead of direct reference

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>${javadoc.version}</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>


### PR DESCRIPTION
This will revert it to the prior parent which is fine for now.